### PR TITLE
Add AI Chat page and navigation link

### DIFF
--- a/app/ai-chat/page.tsx
+++ b/app/ai-chat/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { use, useState, type ChangeEvent } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { MessageData } from "@/lib/types";
+import { postChatMessage } from "@/app/api/aiChatApi";
+import AuthContext from "@/context/AuthContext";
+
+export default function AIChatPage() {
+  const [messages, setMessages] = useState<MessageData[]>([]);
+  const [text, setText] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const { token } = use(AuthContext);
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+  };
+
+  const handleSendMessage = async () => {
+    if (!text.trim()) return;
+    const userMessage: MessageData = {
+      role: "user",
+      content: text,
+      id: uuidv4(),
+    };
+    setMessages((prev) => [...prev, userMessage]);
+    setIsLoading(true);
+    setText("");
+    const chatResponse = await postChatMessage(userMessage, conversationId, token);
+    if (!conversationId) {
+      setConversationId(chatResponse.conversation_id);
+    }
+    const assistantMessage: MessageData = {
+      role: "assistant",
+      content: chatResponse.messages[0].content,
+      id: uuidv4(),
+    };
+    setMessages((prev) => [...prev, assistantMessage]);
+    setIsLoading(false);
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">AI Chat</h1>
+      <div className="border rounded-lg p-4 h-[60vh] overflow-y-auto bg-gray-50 mb-4">
+        {messages.map((m) =>
+          m.role === "assistant" ? (
+            <div key={m.id} className="bg-gray-200 p-3 rounded-lg mb-2 max-w-[80%]">
+              {m.content}
+            </div>
+          ) : (
+            <div key={m.id} className="flex justify-end">
+              <div className="bg-black text-white p-3 rounded-lg mb-2 max-w-[80%]">{m.content}</div>
+            </div>
+          )
+        )}
+        {isLoading && (
+          <div className="bg-gray-200 p-3 rounded-lg mb-2 max-w-[80%]">
+            Loading...
+          </div>
+        )}
+      </div>
+      <div className="flex">
+        <Input
+          placeholder="Type your message..."
+          className="flex-grow"
+          value={text}
+          onChange={handleInputChange}
+        />
+        <Button className="ml-2" onClick={handleSendMessage} disabled={isLoading}>
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/ChatbotButton.tsx
+++ b/components/layout/ChatbotButton.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react";
 import { use, useState, type ChangeEvent } from "react";
+import { usePathname } from "next/navigation";
 import { v4 as uuidv4 } from "uuid";
 import { MessageSquare, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -10,12 +11,17 @@ import { postChatMessage } from "@/app/api/aiChatApi";
 import AuthContext from "@/context/AuthContext";
 
 export default function ChatbotButton() {
+  const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<MessageData[]>([]);
   const [text, setText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const { token } = use(AuthContext);
+
+  if (pathname === "/ai-chat") {
+    return null;
+  }
  
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -56,6 +56,9 @@ export default function Header() {
             <Link href="/kids" className="text-gray-700 hover:text-gray-900">
               Kids
             </Link>
+            <Link href="/ai-chat" className="text-gray-700 hover:text-gray-900">
+              AI Chat
+            </Link>
           </nav>
 
           <div className="flex items-center space-x-4">
@@ -147,6 +150,9 @@ export default function Header() {
               </Link>
               <Link href="/kids" className="text-lg font-medium" onClick={() => setMobileMenuOpen(false)}>
                 Kids
+              </Link>
+              <Link href="/ai-chat" className="text-lg font-medium" onClick={() => setMobileMenuOpen(false)}>
+                AI Chat
               </Link>
               {!token ? (
                 <Link


### PR DESCRIPTION
## Summary
- add "AI Chat" link in header and mobile nav
- create dedicated AI Chat page with chat interface
- hide floating chat button on the AI Chat page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689984d630b083209e193326fa8cf131