### PR TITLE
Improve AI Chat UI with avatars and loading spinner

### DIFF
--- a/app/ai-chat/page.tsx
+++ b/app/ai-chat/page.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { MessageData } from "@/lib/types";
 import { postChatMessage } from "@/app/api/aiChatApi";
 import AuthContext from "@/context/AuthContext";
+import { Bot, Loader2, Send, User } from "lucide-react";
 
 export default function AIChatPage() {
   const [messages, setMessages] = useState<MessageData[]>([]);
@@ -48,18 +49,27 @@ export default function AIChatPage() {
       <div className="border rounded-lg p-4 h-[60vh] overflow-y-auto bg-gray-50 mb-4">
         {messages.map((m) =>
           m.role === "assistant" ? (
-            <div key={m.id} className="bg-gray-200 p-3 rounded-lg mb-2 max-w-[80%]">
-              {m.content}
+            <div key={m.id} className="flex items-start mb-2">
+              <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center mr-2">
+                <Bot className="w-4 h-4" />
+              </div>
+              <div className="bg-gray-200 p-3 rounded-lg max-w-[80%]">{m.content}</div>
             </div>
           ) : (
-            <div key={m.id} className="flex justify-end">
-              <div className="bg-black text-white p-3 rounded-lg mb-2 max-w-[80%]">{m.content}</div>
+            <div key={m.id} className="flex items-start justify-end mb-2">
+              <div className="bg-black text-white p-3 rounded-lg max-w-[80%]">{m.content}</div>
+              <div className="w-8 h-8 bg-black text-white rounded-full flex items-center justify-center ml-2">
+                <User className="w-4 h-4" />
+              </div>
             </div>
           )
         )}
         {isLoading && (
-          <div className="bg-gray-200 p-3 rounded-lg mb-2 max-w-[80%]">
-            Loading...
+          <div className="flex items-start mb-2">
+            <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center mr-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+            </div>
+            <div className="bg-gray-200 p-3 rounded-lg w-fit max-w-[40%]">Loading...</div>
           </div>
         )}
       </div>
@@ -70,8 +80,13 @@ export default function AIChatPage() {
           value={text}
           onChange={handleInputChange}
         />
-        <Button className="ml-2" onClick={handleSendMessage} disabled={isLoading}>
-          Send
+        <Button
+          className="ml-2"
+          onClick={handleSendMessage}
+          disabled={isLoading}
+          aria-label="Send message"
+        >
+          <Send className="h-4 w-4" />
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add lucide-react icons for user and assistant message avatars
- show spinner avatar while awaiting AI response
- replace text send button with icon-only button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899879863a88320a4a6e9107ba9f92c