### PR TITLE
feat: add wishlist functionality

### DIFF
--- a/app/api/wishlistApi.ts
+++ b/app/api/wishlistApi.ts
@@ -1,0 +1,36 @@
+import { WISHLIST_URL } from "@/lib/urls";
+import { WishlistItem, WishlistItemData } from "@/lib/types";
+
+export async function postWishlistItem(item: WishlistItemData, token: string): Promise<WishlistItem> {
+  const res = await fetch(`${WISHLIST_URL}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(item),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json();
+}
+
+export async function getWishlist(token: string): Promise<WishlistItem[]> {
+  const res = await fetch(`${WISHLIST_URL}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json();
+}
+
+export async function deleteWishlistItem(itemId: string, token: string) {
+  const res = await fetch(`${WISHLIST_URL}${itemId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return true;
+}

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -4,12 +4,13 @@ import { useRouter } from "next/navigation"
 import Image from "next/image"
 import { ChevronLeft, Star } from 'lucide-react'
 import { useCart } from "@/hooks/useCart"
+import { useWishlist } from "@/hooks/useWishlist"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { getStorefrontProductById } from "@/app/api/storefrontApi"
-import { CartLineItemData, SFProductWithReview, Size, StorefrontVariant } from "@/lib/types"
+import { CartLineItemData, WishlistItemData, SFProductWithReview, Size, StorefrontVariant } from "@/lib/types"
 import AuthContext from "@/context/AuthContext"
 
 export default function ProductDetailPage({
@@ -22,6 +23,7 @@ export default function ProductDetailPage({
   const [selectedProductVariant, setSelectedProductVariant] = useState<StorefrontVariant | null>(null)
   const [quantity, setQuantity] = useState(1)
   const { addToCart } = useCart()
+  const { addToWishlist } = useWishlist()
   const { id } = use(params)
   const { token } = use(AuthContext)
 
@@ -66,6 +68,19 @@ export default function ProductDetailPage({
         name: product.name,
       }
       addToCart(cartItem, token);
+    };
+
+  const handleAddToWishlist = () => {
+      if (!token) {
+        alert("Please log in to add items to your wishlist.");
+        return;
+      }
+      const item: WishlistItemData = {
+        product_variant_id: selectedProductVariant.id,
+        price: selectedProductVariant.price,
+        name: product.name,
+      };
+      addToWishlist(item, token);
     };
 
    const handleSizeChange = (value: string) => {
@@ -206,6 +221,9 @@ export default function ProductDetailPage({
 
           <Button onClick={handleAddToCart} className="w-full py-6 text-lg" size="lg">
             Add to Cart
+          </Button>
+          <Button onClick={handleAddToWishlist} variant="outline" className="w-full py-6 text-lg mt-2" size="lg">
+            Add to Wishlist
           </Button>
 
           <div className="mt-6 p-4 bg-gray-50 rounded-lg">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,12 +3,15 @@
 import type React from "react";
 
 import { CartProvider } from "@/hooks/useCart";
+import { WishlistProvider } from "@/hooks/useWishlist";
 import AuthProvider from "@/context/AuthProvider";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
-      <CartProvider>{children}</CartProvider>
+      <CartProvider>
+        <WishlistProvider>{children}</WishlistProvider>
+      </CartProvider>
     </AuthProvider>
   );
 }

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useContext, useEffect } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import AuthContext from "@/context/AuthContext";
+import { useWishlist } from "@/hooks/useWishlist";
+import { Button } from "@/components/ui/button";
+
+export default function WishlistPage() {
+  const { token } = useContext(AuthContext);
+  const { wishlistItems, loadWishlist, removeFromWishlist } = useWishlist();
+
+  useEffect(() => {
+    if (token) {
+      loadWishlist(token);
+    }
+  }, [token, loadWishlist]);
+
+  if (!token) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-4">Your Wishlist</h1>
+        <p>Please log in to view your wishlist.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-8">Your Wishlist</h1>
+      {wishlistItems.length === 0 ? (
+        <div className="text-center py-12 bg-gray-50 rounded-lg">
+          <h2 className="text-xl font-medium text-gray-600">Your wishlist is empty</h2>
+          <Button className="mt-4" asChild>
+            <Link href="/">Continue Shopping</Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {wishlistItems.map((item) => (
+            <div key={item.id} className="flex items-center gap-4 p-4 border rounded-lg">
+              <div className="w-20 h-20 relative flex-shrink-0">
+                <Image src={item.image_url || "/placeholder.svg"} alt={item.name} fill className="object-cover rounded-md" />
+              </div>
+              <div className="flex-grow">
+                <h3 className="font-medium">{item.name}</h3>
+                <p className="font-medium">${item.price}</p>
+              </div>
+              <div className="text-right">
+                <Button variant="ghost" className="text-red-500" onClick={() => removeFromWishlist(item.id, token!)}>
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -45,6 +45,11 @@ export default function Footer() {
                   Cart
                 </Link>
               </li>
+              <li>
+                <Link href="/wishlist" className="text-gray-300 hover:text-white">
+                  Wishlist
+                </Link>
+              </li>
             </ul>
           </div>
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import {
   UserCircle,
   LogOut,
   MessageSquare,
+  Heart,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -103,6 +104,10 @@ export default function Header() {
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
+
+            <Link href="/wishlist" className="relative">
+              <Heart className="h-6 w-6 text-gray-700" />
+            </Link>
 
             <Link href="/cart" className="relative">
               <ShoppingCart className="h-6 w-6 text-gray-700" />
@@ -198,6 +203,14 @@ export default function Header() {
               >
                 <ShoppingCart className="h-5 w-5 mr-2" />
                 Cart {totalItems > 0 && `(${totalItems})`}
+              </Link>
+              <Link
+                href="/wishlist"
+                className="text-lg font-medium flex items-center"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                <Heart className="h-5 w-5 mr-2" />
+                Wishlist
               </Link>
             </nav>
           </div>

--- a/components/shared/ProductCard.tsx
+++ b/components/shared/ProductCard.tsx
@@ -4,10 +4,11 @@ import { useContext, useState } from "react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { useCart } from "@/hooks/useCart";
+import { useWishlist } from "@/hooks/useWishlist";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import Link from "next/link";
 import { ProductCardProps } from "@/lib/interfaces";
-import { CartLineItemData, Size } from "@/lib/types";
+import { CartLineItemData, Size, WishlistItemData } from "@/lib/types";
 import AuthContext from "@/context/AuthContext";
 
 export default function ProductCard({ product }: ProductCardProps) {
@@ -23,6 +24,7 @@ export default function ProductCard({ product }: ProductCardProps) {
   }, []);
 
   const { addToCart } = useCart();
+  const { addToWishlist } = useWishlist();
 
   const handleAddToCart = () => {
     if (!token) {
@@ -37,6 +39,19 @@ export default function ProductCard({ product }: ProductCardProps) {
       name: product.name,
     }
     addToCart(cartItem, token);
+  };
+
+  const handleAddToWishlist = () => {
+    if (!token) {
+      alert("Please log in to add items to your wishlist.");
+      return;
+    }
+    const item: WishlistItemData = {
+      product_variant_id: selectedProductVariant.id,
+      price: selectedProductVariant.price,
+      name: product.name,
+    };
+    addToWishlist(item, token);
   };
 
   const handleSizeChange = (value: string) => {
@@ -102,6 +117,9 @@ export default function ProductCard({ product }: ProductCardProps) {
 
         <Button onClick={handleAddToCart} className="w-full">
           Add to Cart
+        </Button>
+        <Button onClick={handleAddToWishlist} variant="outline" className="w-full mt-2">
+          Add to Wishlist
         </Button>
       </div>
     </div>

--- a/hooks/useWishlist.tsx
+++ b/hooks/useWishlist.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { getWishlist, postWishlistItem, deleteWishlistItem } from "@/app/api/wishlistApi";
+import { WishlistItem, WishlistItemData } from "@/lib/types";
+
+interface WishlistContextType {
+  wishlistItems: WishlistItem[];
+  loadWishlist: (token: string) => void;
+  addToWishlist: (item: WishlistItemData, token: string) => void;
+  removeFromWishlist: (itemId: string, token: string) => void;
+}
+
+const WishlistContext = createContext<WishlistContextType | undefined>(undefined);
+
+export function WishlistProvider({ children }: { children: ReactNode }) {
+  const [wishlistItems, setWishlistItems] = useState<WishlistItem[]>([]);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("wishlistItems");
+    if (saved) {
+      setWishlistItems(JSON.parse(saved));
+    }
+  }, []);
+
+  const loadWishlist = async (token: string) => {
+    try {
+      const items = await getWishlist(token);
+      setWishlistItems(items);
+      localStorage.setItem("wishlistItems", JSON.stringify(items));
+    } catch (error) {
+      console.error("Failed to load wishlist:", error);
+    }
+  };
+
+  const addToWishlist = async (item: WishlistItemData, token: string) => {
+    try {
+      const added = await postWishlistItem(item, token);
+      const newState = [...wishlistItems, added];
+      setWishlistItems(newState);
+      localStorage.setItem("wishlistItems", JSON.stringify(newState));
+    } catch (error) {
+      console.error("Failed to add item to wishlist:", error);
+    }
+  };
+
+  const removeFromWishlist = async (itemId: string, token: string) => {
+    try {
+      await deleteWishlistItem(itemId, token);
+      const newState = wishlistItems.filter((item) => item.id !== itemId);
+      setWishlistItems(newState);
+      localStorage.setItem("wishlistItems", JSON.stringify(newState));
+    } catch (error) {
+      console.error("Failed to remove item from wishlist:", error);
+    }
+  };
+
+  return (
+    <WishlistContext.Provider value={{ wishlistItems, loadWishlist, addToWishlist, removeFromWishlist }}>
+      {children}
+    </WishlistContext.Provider>
+  );
+}
+
+export function useWishlist() {
+  const context = useContext(WishlistContext);
+  if (context === undefined) {
+    throw new Error("useWishlist must be used within a WishlistProvider");
+  }
+  return context;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -146,6 +146,20 @@ export type CartLineItem = CartLineItemBase & {
   image_url?: string;
 };
 
+type WishlistItemBase = {
+  product_variant_id: string;
+  price: number;
+  name: string;
+};
+
+export type WishlistItemData = WishlistItemBase;
+
+export type WishlistItem = WishlistItemBase & {
+  id: string;
+  user_id: string;
+  image_url?: string;
+};
+
 type OrderBase = {
   full_name: string;
   email: string;

--- a/lib/urls.ts
+++ b/lib/urls.ts
@@ -11,6 +11,7 @@ export const PRODUCT_VARIANTS_URL = `${API_URL}/product-variants/`;
 export const STOREFRONT_URL = `${API_URL}/storefront/`;
 export const AUTH_URL = `${API_URL}/auth/`;
 export const CART_URL = `${API_URL}/cart/`;
+export const WISHLIST_URL = `${API_URL}/wishlist/`;
 export const ORDER_URL = `${API_URL}/orders/`;
 export const REVIEW_URL = `${API_URL}/reviews/`;
 


### PR DESCRIPTION
## Summary
- add wishlist API, types, and state management
- allow adding/removing variants to wishlist from product pages
- create wishlist page and navigation links

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68998cc781788320a4a1e6a0161a31e7