### PR TITLE
refactor: replace browser alerts with shadcn component

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import AuthContext from "@/context/AuthContext";
 import { OrderData } from "@/lib/types";
 import { OrderStatusEnum } from "@/lib/enums";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 
 const initialFormState: OrderData = {
   full_name: "",
@@ -29,6 +30,7 @@ export default function CartPage() {
   const router = useRouter();
   const [formData, setFormData] = useState(initialFormState);
   const [isLoading, setIsLoading] = useState(false);
+  const [alertMessage, setAlertMessage] = useState("");
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -43,7 +45,8 @@ export default function CartPage() {
       router.push(`/order/${order.id}`);
     } catch (error) {
       console.error("Error placing order:", error);
-      alert("Failed to place order. Please try again.");
+      setAlertMessage("Failed to place order. Please try again.");
+      setTimeout(() => setAlertMessage(""), 3000);
     }
   };
 
@@ -59,6 +62,11 @@ export default function CartPage() {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {alertMessage && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertDescription>{alertMessage}</AlertDescription>
+        </Alert>
+      )}
       <h1 className="text-3xl font-bold mb-8">Your Cart</h1>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge"
 import { getStorefrontProductById } from "@/app/api/storefrontApi"
 import { CartLineItemData, WishlistItemData, SFProductWithReview, Size, StorefrontVariant } from "@/lib/types"
 import AuthContext from "@/context/AuthContext"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 
 export default function ProductDetailPage({
   params
@@ -26,6 +27,7 @@ export default function ProductDetailPage({
   const { addToWishlist } = useWishlist()
   const { id } = use(params)
   const { token } = use(AuthContext)
+  const [alertMessage, setAlertMessage] = useState("")
 
   useEffect(() => {
     (async () => {
@@ -55,9 +57,14 @@ export default function ProductDetailPage({
       return [...acc, size];
     }, []);
 
+  const showAlert = (message: string) => {
+    setAlertMessage(message)
+    setTimeout(() => setAlertMessage(""), 3000)
+  }
+
   const handleAddToCart = () => {
       if (!token) {
-        alert("Please log in to add items to your cart.");
+        showAlert("Please log in to add items to your cart.")
         return;
       }
         
@@ -72,7 +79,7 @@ export default function ProductDetailPage({
 
   const handleAddToWishlist = () => {
       if (!token) {
-        alert("Please log in to add items to your wishlist.");
+        showAlert("Please log in to add items to your wishlist.")
         return;
       }
       const item: WishlistItemData = {
@@ -122,6 +129,11 @@ export default function ProductDetailPage({
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {alertMessage && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertDescription>{alertMessage}</AlertDescription>
+        </Alert>
+      )}
       {/* Back button */}
       <Button variant="ghost" className="mb-6 flex items-center gap-1" onClick={() => router.back()}>
         <ChevronLeft className="h-4 w-4" />

--- a/components/home/ContactNewsletter.tsx
+++ b/components/home/ContactNewsletter.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 
 export default function ContactNewsletter() {
   const [contactForm, setContactForm] = useState({
@@ -16,6 +17,12 @@ export default function ContactNewsletter() {
   })
 
   const [newsletter, setNewsletter] = useState("")
+  const [alertMessage, setAlertMessage] = useState("")
+
+  const showAlert = (message: string) => {
+    setAlertMessage(message)
+    setTimeout(() => setAlertMessage(""), 3000)
+  }
 
   const handleContactChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target
@@ -24,18 +31,23 @@ export default function ContactNewsletter() {
 
   const handleContactSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    alert("Message sent! (This would send the message in a real app)")
+    showAlert("Message sent! (This would send the message in a real app)")
     setContactForm({ name: "", email: "", message: "" })
   }
 
   const handleNewsletterSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    alert("Subscribed to newsletter! (This would subscribe in a real app)")
+    showAlert("Subscribed to newsletter! (This would subscribe in a real app)")
     setNewsletter("")
   }
 
   return (
     <section className="container mx-auto px-4 py-8">
+      {alertMessage && (
+        <Alert className="mb-4">
+          <AlertDescription>{alertMessage}</AlertDescription>
+        </Alert>
+      )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
         <div>
           <h2 className="text-3xl font-bold mb-6">Contact Us</h2>

--- a/components/shared/ProductCard.tsx
+++ b/components/shared/ProductCard.tsx
@@ -10,10 +10,12 @@ import Link from "next/link";
 import { ProductCardProps } from "@/lib/interfaces";
 import { CartLineItemData, Size, WishlistItemData } from "@/lib/types";
 import AuthContext from "@/context/AuthContext";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 
 export default function ProductCard({ product }: ProductCardProps) {
   const { token } = useContext(AuthContext);
   const [selectedProductVariant, setSelectedProductVariant] = useState(product.variants[0])
+  const [alertMessage, setAlertMessage] = useState("")
   const availableSizes: Size[] = product.variants.reduce<Size[]>((acc, variant) => {
     if (acc.map((s) => s.id).includes(variant.size_id)) return acc
     const size: Size = {
@@ -26,9 +28,14 @@ export default function ProductCard({ product }: ProductCardProps) {
   const { addToCart } = useCart();
   const { addToWishlist } = useWishlist();
 
+  const showAlert = (message: string) => {
+    setAlertMessage(message)
+    setTimeout(() => setAlertMessage(""), 3000)
+  }
+
   const handleAddToCart = () => {
     if (!token) {
-      alert("Please log in to add items to your cart.");
+      showAlert("Please log in to add items to your cart.")
       return;
     }
 
@@ -43,7 +50,7 @@ export default function ProductCard({ product }: ProductCardProps) {
 
   const handleAddToWishlist = () => {
     if (!token) {
-      alert("Please log in to add items to your wishlist.");
+      showAlert("Please log in to add items to your wishlist.")
       return;
     }
     const item: WishlistItemData = {
@@ -75,6 +82,11 @@ export default function ProductCard({ product }: ProductCardProps) {
       </Link>
 
       <div className="p-4">
+        {alertMessage && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>{alertMessage}</AlertDescription>
+          </Alert>
+        )}
         <Link href={`/product/${product.id}`} className="block">
           <h3 className="font-medium text-lg hover:underline">{product.name}</h3>
           <p className="text-gray-500 text-sm mb-2">{product.category_name}</p>


### PR DESCRIPTION
## Summary
- replace native alert() calls with shadcn Alert component across product UI and forms
- show login and submission feedback using inline Alerts instead of browser popups

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68998e996b6483208202650b4cd9d99b